### PR TITLE
Just a few extra reference links

### DIFF
--- a/dotnet/1. setup.md
+++ b/dotnet/1. setup.md
@@ -4,7 +4,7 @@ To get started with the Rock Paper Scissors workshop in .NET, you'll need:
 
 1. Visual Studio Code or Visual Studio
 2. .NET 7.0 SDK or later installed
-3. GitHub Copilot extension installed and authenticated
+3. GitHub Copilot extension installed and authenticated. [Visual Studio instructions](https://learn.microsoft.com/en-us/visualstudio/ide/visual-studio-github-copilot-install-and-states?view=vs-2022), [Visual Studio Code instructions](https://code.visualstudio.com/docs/copilot/setup#_step-2-install-the-github-copilot-extension)
 4. Git installed
 
 ### Verify Your Setup

--- a/dotnet/4. additional resources.md
+++ b/dotnet/4. additional resources.md
@@ -4,6 +4,7 @@
 - [xUnit Testing Framework](https://xunit.net/)
 - [GitHub Copilot Documentation](https://docs.github.com/en/copilot)
 - [REST API Best Practices](https://docs.microsoft.com/en-us/azure/architecture/best-practices/api-design)
+- [GitHub Copilot Patterns and Exercises](https://patterns.hattori.dev/)
 
 ## Next Steps
 


### PR DESCRIPTION
This pull request includes updates to the documentation for the Rock Paper Scissors workshop in .NET. The changes primarily focus on enhancing the setup instructions and providing additional resources.

Documentation updates:

* [`dotnet/1. setup.md`](diffhunk://#diff-f64de4e98eb09d6efe31a2feb47c4e053fed45be79b8706348d2e04b2275f76fL7-R7): Added links to Visual Studio and Visual Studio Code instructions for installing and authenticating the GitHub Copilot extension.
* [`dotnet/4. additional resources.md`](diffhunk://#diff-14b5a3bb524074785838736c255b8a69f2a466d7f8da24d12f1dae4b5e6084e5R7): Added a link to GitHub Copilot Patterns and Exercises.